### PR TITLE
make <strong> text explictly bold

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -50,3 +50,9 @@ $on-laptop:        800px;
         "layout",
         "syntax-highlighting"
 ;
+
+strong {
+    // Firefox won't render the strong tag as bold here unless it's explicitly
+    // told to do so.
+    font-weight: bold;
+}


### PR DESCRIPTION
Using Firefox 36, the `<strong>` elements in this document were not
explictly rendered as bold - they just had the same text width.

This updates the CSS to explicitly set the font-weight to bold within
`<strong>` tags, so the same behavior is seen between Firefox/Chrome.
