### PR TITLE
Add 18f-pages transition plugin

### DIFF
--- a/_plugins/18f-pages.rb
+++ b/_plugins/18f-pages.rb
@@ -1,0 +1,7 @@
+PAGES_BRANCHES = ['master']
+
+if PAGES_BRANCHES.include? ENV['BRANCH']
+    Jekyll::Hooks.register :site, :pre_render do |site|
+        site.config['baseurl'] = '/site/18f/automated-testing-playbook'
+    end
+end


### PR DESCRIPTION
This should fix the `baseurl` issue on [this URL](https://federalist-proxy.app.cloud.gov/site/18f/automated-testing-playbook/), which will allow us to run tests before transitioning over to the new [subdomain URL](https://automated-testing-playbook.18f.gov/).